### PR TITLE
Support google protobuf v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "google/protobuf": "^3.3.0"
+        "google/protobuf": "^3.3 || ^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
If google protobuf v4 is not allowed, the package version `1.0.0beta5` will be installed, which breaks the application.